### PR TITLE
Fix installation by dynamically specifying the `README.rst` file path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import os
 from setuptools import setup, find_packages
 
 # Get the directory where setup.py is located

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
 from setuptools import setup, find_packages
 
+# Get the directory where setup.py is located
+current_directory = os.path.abspath(os.path.dirname(__file__))
+
+# Use that directory to construct the absolute path to README.rst
+with open(os.path.join(current_directory, 'README.rst'), 'r') as f:
+    long_description = f.read()
+
+
 setup(
     name = 'troppo',
     version = '0.0.5',
@@ -13,7 +21,7 @@ setup(
     license = 'GNU General Public License v3.0',
     keywords = 'pathway analysis metabolic model',
     url = 'https://github.com/BioSystemsUM/troppo',
-    long_description = open('README.rst').read(),
+    long_description = long_description,
     classifiers = [
         'Development Status :: 4 - Beta',
         'Topic :: Scientific/Engineering :: Bio-Informatics',


### PR DESCRIPTION
I was having issues installing troppo resulting from the `README.rst` file not existing, when it obviously does. This pull request fixes that error